### PR TITLE
docs: :memo: add documentation on specifics about tasks done during iteration

### DIFF
--- a/entries/iteration-tasks.qmd
+++ b/entries/iteration-tasks.qmd
@@ -1,0 +1,29 @@
+---
+title: "Tasks during iterations"
+date: last-modified
+---
+
+While specific details about what we do during an iteration is described
+in the [iteration](iteration.qmd) guide, there are some speific
+situations that need a bit more detail.
+
+In general, tasks we work on during the iteration should support the
+overall iteration goal. However, there are several cases when we should
+work on tasks unrelated to the goal. Specifically:
+
+-   Whenever a decision is made, create a decision post about it as near
+    to the time of decision (or before making the decision) as possible.
+-   Whenever a team member learns something and feels like it would be
+    useful to share with the team, create a learning post about it as
+    near to the time of learning as possible.
+
+Likewise, while issues are assigned a priority, our individual and team
+priorities are to, in order:
+
+-   Respond to reviewer comments on our own pull requests.
+-   Respond to issues where we are tagged/mentioned (`@`).
+-   Review pull requests from others.
+-   Work on the assigned highest priority issues.
+-   Respond to comments and questions in issues, unless it is a
+    discussion issue, where the assigned team member will seek out and
+    request our comments.

--- a/entries/iteration-tasks.qmd
+++ b/entries/iteration-tasks.qmd
@@ -9,13 +9,16 @@ situations that need a bit more detail.
 
 In general, tasks we work on during the iteration should support the
 overall iteration goal. However, there are several cases when we should
-work on tasks unrelated to the goal. Specifically:
+work on tasks unrelated to the goal of the current iteration. Specifically:
 
 -   Whenever a decision is made, create a decision post about it as near
-    to the time of decision (or before making the decision) as possible.
+    to the time of decision as possible (or before making the decision).
 -   Whenever a team member learns something and feels like it would be
     useful to share with the team, create a learning post about it as
     near to the time of learning as possible.
+-   If tasks from the previous iteration are "In Progress" or "In Review" 
+    at the beginning of a new iteration and it makes sense to finish it 
+    during the next iteration.
 
 Likewise, while issues are assigned a priority, our individual and team
 priorities are to, in order:


### PR DESCRIPTION
## Description

This is based on things that came up during the retrospective. Mostly it is make the iteration guide a bit smaller, and to add on some higher level priorities to focus on during the iteration.

Closes #134 