### PR TITLE
docs: add section on plantuml seedcase theme

### DIFF
--- a/how-we-work/create-puml-images.qmd
+++ b/how-we-work/create-puml-images.qmd
@@ -57,14 +57,10 @@ top of the file:
 ``` bash
 @startuml diagram-name
 
-!theme seedcase from ../_extensions/seedcase-project/seedcase-theme
+!theme seedcase from https://raw.githubusercontent.com/seedcase-project/seedcase-theme/main
 
 [add your diagram code here] 
 
 @enduml
 ```
 
-Note that depending on the location of your `.puml` file, you might need
-to adjust the path above, so that it points to the correct location of
-the theme. The script above assumes that the PlantUML file is located in
-a subdirectory one level below the root of the repository.

--- a/how-we-work/create-puml-images.qmd
+++ b/how-we-work/create-puml-images.qmd
@@ -3,14 +3,17 @@ title: Creating PlantUML images
 date: last-modified
 ---
 
-We use [PlantUML](https://plantuml.com) to create diagrams across most of content, such as:
+We use [PlantUML](https://plantuml.com) to create diagrams across most
+of content, such as:
 
-1. [C4 diagrams](https://c4model.com) to visualise the software architecture.
-2. [Sequence diagrams](https://plantuml.com/sequence-diagram) that visualise how and in what order things work together.
+1.  [C4 diagrams](https://c4model.com) to visualise the software
+    architecture.
+2.  [Sequence diagrams](https://plantuml.com/sequence-diagram) that
+    visualise how and in what order things work together.
 
-To create PNG images of the PlantUML files, open a Terminal while inside the
-project that has the PlantUML files and that has the `justfile`, and run the
-command:
+To create PNG images of the PlantUML files, open a Terminal while inside
+the project that has the PlantUML files and that has the `justfile`, and
+run the command:
 
 ``` bash
 just generate-puml-all
@@ -21,6 +24,11 @@ If you want to generate a specific image, run:
 ``` bash
 just generate-puml PATH/TO/PUML
 ```
+
+You need to have both Docker and Just installed and have Docker running
+in the background in order for these commands to work. To see how to
+install these programs, check out the entry on [software](software.qmd))
+for more details.
 
 ## Seedcase theme
 

--- a/how-we-work/create-puml-images.qmd
+++ b/how-we-work/create-puml-images.qmd
@@ -22,6 +22,30 @@ If you want to generate a specific image, run:
 just generate-puml PATH/TO/PUML
 ```
 
-You need to have both Docker and Just installed and have Docker running in the
-background in order for these commands to work. To see how to install these
-programs, check out the entry on [software](software.qmd)) for more details.
+## Seedcase theme
+
+We have created a PlantUML theme that we use across all our PlantUML
+diagrams. This theme is located in the
+[`seedcase-theme`](https://github.com/seedcase-project/seedcase-theme)
+repository and is synced to the remaining Seedcase repositories. In
+these repositories, the theme is located in the
+`_extensions/seedcase-project/seedcase-theme` directory.
+
+To include the theme in a PlantUML file, add the following line at the
+top of the file:
+
+``` bash
+@startuml diagram-name
+
+!theme seedcase from ../_extensions/seedcase-project/seedcase-theme
+
+[add your diagram code here] 
+
+@enduml
+```
+
+Note that depending on the location of your `.puml` file, you might need
+to adjust the path above, so that it points to the correct location of
+the theme. The script above assumes that the PlantUML file is located in
+a subdirectory one level below the root of the repository.
+

--- a/how-we-work/create-puml-images.qmd
+++ b/how-we-work/create-puml-images.qmd
@@ -30,6 +30,18 @@ in the background in order for these commands to work. To see how to
 install these programs, check out the entry on [software](software.qmd))
 for more details.
 
+## Style guide
+
+When you create a PlantUML diagram, please follow the style guide below:
+
+1.  Use the Seedcase theme, see below.
+2.  Use sentence case (capitalise the first word only) for diagram
+    titles and texts.
+3.  Ensure that you use the same wording and ordering of elements in the
+    diagram as in the surrounding text.
+4.  For C4 diagrams, add a legend by writing `SHOW_LEGEND()` or
+    `SHOW_FLOATING_LEGEND()` at the end of the diagram.
+
 ## Seedcase theme
 
 We have created a PlantUML theme that we use across all our PlantUML
@@ -56,4 +68,3 @@ Note that depending on the location of your `.puml` file, you might need
 to adjust the path above, so that it points to the correct location of
 the theme. The script above assumes that the PlantUML file is located in
 a subdirectory one level below the root of the repository.
-


### PR DESCRIPTION
## Description

<!-- 
This template covers all PRs for Seedcase, please note that if you are
submitting a PR for changes to:

a) General documentation you should delete the sections Testing, Code
Documentation, and the first part of the Author Checklist.

b) Code you should delete the second section of the Author Checklist.

Otherwise, delete any sections that don't apply.
-->

<!-- DO NOT LEAVE THIS SECTION BLANK -->

- This PR adds a section on how to use the PlantUML Seedcase theme (which will be pushed to the `seedcase-theme` repo as soon as it has been tested on the new C4 diagrams that Kris will create  seedcase-project/seedcase-theme#37).
- It also adds a short "style guide" which addresses the relevant points from https://github.com/seedcase-project/design/issues/23 . @lwjohnst86 Is this the correct location for this? Would it fit better in `design/style`?

**Note** this small section can be reviewed and merged even though the theme hasn't been merged yet.

## Issues

Closes seedcase-project/design/issues/23