### PR TITLE
docs: :memo: add section on how to format Markdown in VS Code

### DIFF
--- a/how-we-work/workflow.qmd
+++ b/how-we-work/workflow.qmd
@@ -205,3 +205,5 @@ changes, we use VS Code. To format a Quarto file, follow these steps:
     Palette again, type "Source Mode", and select the option that
     appears ("Quarto: Edit in Source mode").
 5.  Now, you're ready to commit your changes.
+
+Alternatively, use `Ctrl/Cmd-Shift-F4` keybinding to switch to Visual Mode, then use the same keybind to switch back to Source Mode.

--- a/how-we-work/workflow.qmd
+++ b/how-we-work/workflow.qmd
@@ -214,15 +214,17 @@ Stacking pull requests are useful when the task we are working on is
 fairly large or modifies many files in different ways. We want to keep
 pull requests small enough to be easily reviewed, as a pull request's
 change gets larger, it becomes increasingly harder to review. So to keep
-each stacked pull request small while ensuring that the final pull request is atomic
-and “squashable".
+each stacked pull request small while ensuring that the final pull
+request is atomic and “squashable".
 
-Stacked pull requests are not without challenges. So, when stacking
-pull requests, we aim to follow these guidelines:
+Stacked pull requests are not without challenges. So, when stacking pull
+requests, we aim to follow these guidelines:
 
 1.  Firstly, as much as possible, *avoid* stacking pull requests.
 2.  If a stacked pull request is necessary, then clearly communicate
-    that it will be a stacked pull request in the description by clearly writing that this is a stacked pull request and linking to the relevant pull request(s).
+    that it will be a stacked pull request in the description by clearly
+    writing that this is a stacked pull request and linking to the
+    relevant pull request(s).
 3.  Then, a team member with merge permissions will *hold off* merging
     until all development has finished in the stacked pull requests.
 4.  As requests for changes come in, it is the responsibility of the
@@ -249,4 +251,5 @@ changes, we use VS Code. To format a Quarto file, follow these steps:
     appears ("Quarto: Edit in Source mode").
 5.  Now, you're ready to commit your changes.
 
-Alternatively, use `Ctrl/Cmd-Shift-F4` keybinding to switch to Visual Mode, then use the same keybind to switch back to Source Mode.
+Alternatively, use `Ctrl/Cmd-Shift-F4` keybinding to switch to Visual
+Mode, then use the same keybind to switch back to Source Mode.

--- a/how-we-work/workflow.qmd
+++ b/how-we-work/workflow.qmd
@@ -185,3 +185,23 @@ While writing Python code, follow these guidelines:
     instructions. For instance:
     -   Write docstrings for every function, class, and method.
     -   Include type hints for both inputs and returns.
+
+## Writing documentation (`.qmd` files)
+
+When writing documentation, we write in Quarto Markdown (`.qmd`) files.
+See the [Quarto
+documentation](https://quarto.org/docs/authoring/markdown-basics.html)
+for more information on how to write Markdown.
+
+To format the Markdown files, as we aim to do before committing our
+changes, we use VS Code. To format a Quarto file, follow these steps:
+
+1.  Open the Command Palette in VS Code by pressing `Ctrl/Cmd-Shift-P`.
+2.  Type "Visual Mode" and select the option that appears ("Quarto: Edit
+    in Visual Mode").
+3.  In Visual Mode, save the file (`Ctrl/Cmd-S`). This will format the
+    file.
+4.  To go back to the Source Mode (the default mode), open the Command
+    Palette again, type "Source Mode", and select the option that
+    appears ("Quarto: Edit in Source mode").
+5.  Now, you're ready to commit your changes.


### PR DESCRIPTION
## Description

I noticed some missing formatting in seedcase-project/community#107 and thought it would be nice to have something to refer to in terms of how we format Markdown files currently.


<!-- Please delete as appropriate: -->
This PR needs a quick review.

## Checklist

- [X] Ran spell-check
- [X] Formatted Markdown
- [X] Ran `just run-all`
