### PR TITLE
docs: :pencil2: remove "add" in feature branch example

### DIFF
--- a/how-we-work/workflow.qmd
+++ b/how-we-work/workflow.qmd
@@ -61,7 +61,7 @@ includes a type and a branch description. Specifically, the format of a
 conventional branch name is `<type>/<branch>`, where `<type>` is the
 type of the branch and `<branch>` is a short description of the change
 that will be made. The description should be written in imperative mood
-using kebab-case. For example `feat/add-new-feature` or `fix/bug-fix`.
+using kebab-case. For example `feat/new-feature` or `fix/bug-fix`.
 
 #### Using the VS Code extension
 


### PR DESCRIPTION
## Description

When using "feat" this implies that a new feature is *added*, so no need to use "add".

<!-- Please delete as appropriate: -->
This PR needs no review.
