### PR TITLE
docs: :memo: add `just` section to GenomeDK guide

### DIFF
--- a/how-we-work/genome-dk.qmd
+++ b/how-we-work/genome-dk.qmd
@@ -70,7 +70,10 @@ Quarto. Finally, if you want to run recipes in the
 ### Installing uv {#installing-uv}
 
 Log in to GenomeDK (either through [SSH](#ssh) or the [desktop
-interface](#desktop)) and open a terminal window. Run:
+interface](#desktop)) and open a terminal window. Following uv's
+[installation
+guide](https://docs.astral.sh/uv/getting-started/installation/#standalone-installer),
+run:
 
 ``` {.bash filename="Terminal"}
 curl -LsSf https://astral.sh/uv/install.sh | sh
@@ -94,7 +97,10 @@ Notes:
 ### Installing `just`
 
 Log in to GenomeDK (either through [SSH](#ssh) or the [desktop
-interface](#desktop)) and open a terminal window. Run:
+interface](#desktop)) and open a terminal window. Following `just`'s
+[installation
+guide](https://just.systems/man/en/pre-built-binaries.html#pre-built-binaries),
+run:
 
 ``` {.bash filename="Terminal"}
 curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to ~/bin

--- a/how-we-work/genome-dk.qmd
+++ b/how-we-work/genome-dk.qmd
@@ -63,7 +63,9 @@ GenomeDK's website.
 
 To develop Seedcase projects on GenomeDK, you will need to install uv.
 If you want to render markdown documents, you will also need to install
-Quarto.
+Quarto. Finally, if you want to run recipes in the
+[`justfile`](workflow.qmd#workflow-helper), you will need to install
+`just`.
 
 ### Installing uv {#installing-uv}
 
@@ -88,6 +90,15 @@ Notes:
 -   Step 4: as the instructions say, you can probably skip this step
 -   If VS Code is open, you'll need to restart it to detect the Quarto
     CLI
+
+### Installing `just`
+
+Log in to GenomeDK (either through [SSH](#ssh) or the [desktop
+interface](#desktop)) and open a terminal window. Run:
+
+``` {.bash filename="Terminal"}
+curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to ~/bin
+```
 
 ## Developing with VS Code
 


### PR DESCRIPTION
# Description

This adds a missing section to the GenomeDK guide about installing `just`.

This PR needs a quick.

## Checklist

- [x] Formatted Markdown
- [x] Ran `just run-all`
