### PR TITLE
refactor: ♻️ add `--no-checkout` to working outside GenomeDK section

### DIFF
--- a/how-we-work/genome-dk.qmd
+++ b/how-we-work/genome-dk.qmd
@@ -283,7 +283,7 @@ run the following from the root of the Data Package:
 
 ``` {.bash filename="Terminal"}
 # Show LFS-tracked files as pointers in the working tree
-git config --local filter.lfs.smudge  "cat"
+git config --local filter.lfs.smudge "cat"
 # Do not require Git LFS to be installed
 git config --local filter.lfs.required false
 # Disable all LFS processing for tracked files

--- a/how-we-work/genome-dk.qmd
+++ b/how-we-work/genome-dk.qmd
@@ -266,10 +266,20 @@ In fact, it is not possible to download the data files via Git LFS,
 because the LFS store path points to a local folder on GenomeDK that
 your machine cannot access.
 
-You don't need Git LFS installed locally, but you do have to tell Git
-not to attempt to fetch data files tracked by Git LFS, as this would
-lead to an error. After cloning the repo, run the following from the
-root of the Data Package:
+You don't need Git LFS installed locally, but you do have to tell Git not to
+attempt to fetch data files tracked by Git LFS, as this would lead to an error.
+
+First, clone the repo without checkout:
+
+```bash {filename="Terminal"}
+git clone https://github.com/repo-org/repo-name.git --no-checkout
+```
+
+Using `--no-checkout` avoids Git immediately trying to check out files and run
+the Git LFS smudge filter, which reads the Git LFS pointer files and tries to
+write the contents of the tracked files to standard output. This would fail
+because the LFS store is only accessible on GenomeDK. After cloning the repo,
+run the following from the root of the Data Package:
 
 ``` {.bash filename="Terminal"}
 # Show LFS-tracked files as pointers in the working tree

--- a/how-we-work/genome-dk.qmd
+++ b/how-we-work/genome-dk.qmd
@@ -289,7 +289,7 @@ git config --local filter.lfs.smudge "cat"
 git config --local filter.lfs.required false
 # Disable all LFS processing for tracked files
 git config --local filter.lfs.process ""
-# Checkout now that Git LFS has been disabled. 
+# Checkout now that Git LFS has been disabled.
 git checkout
 ```
 

--- a/how-we-work/genome-dk.qmd
+++ b/how-we-work/genome-dk.qmd
@@ -278,8 +278,9 @@ git clone https://github.com/repo-org/repo-name.git --no-checkout
 Using `--no-checkout` avoids Git immediately trying to check out files and run
 the Git LFS smudge filter, which reads the Git LFS pointer files and tries to
 write the contents of the tracked files to standard output. This would fail
-because the LFS store is only accessible on GenomeDK. After cloning the repo,
-run the following from the root of the Data Package:
+because the LFS store is only accessible on GenomeDK.
+
+After cloning the repo, run the following from the root of the Data Package:
 
 ``` {.bash filename="Terminal"}
 # Show LFS-tracked files as pointers in the working tree

--- a/how-we-work/genome-dk.qmd
+++ b/how-we-work/genome-dk.qmd
@@ -288,6 +288,8 @@ git config --local filter.lfs.smudge  "cat"
 git config --local filter.lfs.required false
 # Disable all LFS processing for tracked files
 git config --local filter.lfs.process ""
+# Checkout now that Git LFS has been disabled. 
+git checkout
 ```
 
 With this setup, you won't have access to the actual data or be able to


### PR DESCRIPTION
# Description

From @martonvago. 

Without this, I found that a lot of files (100+) were "modified" after cloning:

<img width="341" height="775" alt="image" src="https://github.com/user-attachments/assets/20541e58-fc14-4bf5-b0f0-39ccb210f76c" />

Needs a quick review.