### PR TITLE
feat: ✨ add guideline for how to review PRs

### DIFF
--- a/how-we-work/pr-reviews.qmd
+++ b/how-we-work/pr-reviews.qmd
@@ -1,0 +1,16 @@
+---
+title: "Reviewing pull requests"
+---
+
+Here are a few guidelines to keep PRs small, to keep them moving along, and to
+prevent/limit them from being blocked/in review for too long.
+
+- Keep discussions **sharply focused** on the content of the PR itself. General
+  discussions or questions should either be asked in a targeted issue or asked
+  in the Discord channel so everyone can also see.
+- When a PR gets too many comments (e.g. >50) or commits (e.g. >25), this is a
+  good indication to split the PR up into smaller PRs, since it is likely that
+  only parts of the PR are generating the most discussions.
+- For small sections of an otherwise atomic PR that generate extensive
+  discussions, small targeted issues should be made to continue the discussion
+  there for those specific topics.


### PR DESCRIPTION
# Description

We've started getting PRs that get too much discussions and remain open for too long. The PR mechanism isn't designed for that. So this guideline sets some "limits" to how we use/interact with reviewing PRs.

Needs a thorough review.

## Checklist

- [x] Ran `just run-all`
